### PR TITLE
Updates initiatives list

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -111,7 +111,24 @@
             </ul>
           </li>
 
-        </tbody>
+          <li class="list_row">
+            <ul class="list_columns">
+              <li><strong>Avental do Bem</strong></li>
+              <li>Doação de aventais de manga longa impermeáveis para profissionais de saúde na linha de frente do combate ao Covid-19.</li>
+              <li data-th="Cidade">Recife</li>
+              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/corrente-do-bem-avental-protecao-covid-19">https://www.vakinha.com.br/vaquinha/corrente-do-bem-avental-protecao-covid-19</a></li>
+            </ul>
+          </li>
+
+          <li class="list_row">
+            <ul class="list_columns">
+              <li><strong>De mãos dadas com a cultura</strong></li>
+              <li>De mãos dadas com a Cultura é uma ação sociocultural idealizada pelo Grupo Destramelar com o intuito de doar cestas básicas a artistas da cultura popular (dança, música, teatro, circo...) bem como entidades afins que promovem ações culturais em comunidades em Recife.</li>
+              <li data-th="Cidade">Recife</li>
+              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/de-maos-dadas-com-a-cultura">https://www.vakinha.com.br/vaquinha/de-maos-dadas-com-a-cultura</a></li>
+            </ul>
+          </li>
+        </ul>
       </section>
     </section>
 
@@ -163,7 +180,7 @@
               <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/p/B_xL8AIgLNF">https://www.instagram.com/p/B_xL8AIgLNF</a></li>
             </ul>
           </li>
-        </tbody>
+        </ul>
       </section>
     </section>
 
@@ -217,7 +234,7 @@
               <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/comerciantes-informais-do-recife-precisam-da-sua-atencao">https://www.vakinha.com.br/vaquinha/comerciantes-informais-do-recife-precisam-da-sua-atencao</a></li>
             </ul>
           </li>
-        </tbody>
+        </ul>
       </section>
     </section>
 
@@ -254,7 +271,7 @@
               <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/unificadospsr">https://www.instagram.com/unificadospsr</a></li>
             </ul>
           </li>
-        </tbody>
+        </ul>
       </section>
     </section>
   </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -150,14 +150,6 @@
         <ul>
           <li class="list_row">
             <ul class="list_columns">
-              <li><strong>ONG Juntos</strong></li>
-              <li>Através de doações recebidas, a ONG repassa aos moradores de ruas, às creches e asilos, aos lares de animais, dentre outros, comidas, roupas, remédios, etc. Durante as ações, farão a transmissão via redes sociais e posteriormente toda a prestação de contas será realizada no site (planilhas, balanços, notas fiscais, extratos bancários, etc).</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="http://ongjuntos.org.br/formas-de-doar">http://ongjuntos.org.br/formas-de-doar</a></li>
-            </ul>
-          </li>
-          <li class="list_row">
-            <ul class="list_columns">
               <li><strong>Livroteca Brincante do Pina</strong></li>
               <li>A instituição está arrecadando diversos itens para distribuição de cestas básicas e materiais de limpeza. Doe alimentos, água, álcool 70%, sabão, detergente neutro, máscaras para as famílias da Comunidade do Bode-Pina-Recife.</li>
               <li data-th="Cidade">Recife</li>
@@ -169,7 +161,7 @@
               <li><strong>Maracatu Nação Leão Coroado</strong></li>
               <li>Campanha para arrecadação de alimentos e materiais de higiene para auxiliar na sobrevivência das famílias carentes das periferias de Recife e Olinda.</li>
               <li data-th="Cidade">Recife e Olinda</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/p/B-QSNqGHlcX">https://www.instagram.com/p/B-QSNqGHlcX</a></li>
+              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/p/CNGo9TVL-P7">https://www.instagram.com/p/CNGo9TVL-P7</a></li>
             </ul>
           </li>
           <li class="list_row">
@@ -177,7 +169,7 @@
               <li><strong>Núcleo de Apoio à Criança com Câncer</strong></li>
               <li>Organização não governamental que oferece apoio biopsicossocial a crianças e adolescentes carentes em tratamento contra o câncer nos hospitais públicos de Recife oferecendo albergue para pacientes do interior de PE e outros estados, alimentação, transporte aos hospitais, cestas básicas, suplementação alimentar, fraldas e todo o suporte para continuidade do tratamento.</li>
               <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/p/B_xL8AIgLNF">https://www.instagram.com/p/B_xL8AIgLNF</a></li>
+              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.instagram.com/p/COBQPIUguRv">https://www.instagram.com/p/COBQPIUguRv</a></li>
             </ul>
           </li>
         </ul>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -41,15 +41,6 @@
         <ul>
           <li class="list_row">
             <ul class="list_columns">
-              <li><strong>Pernambuco Solidário</strong></li>
-              <li>O Governo de Pernambuco se uniu a organizações sem fins lucrativos nesta luta global e criou o programa “Pernambuco Solidário contra o Coronavírus”, que vai reforçar as ações de amparo a pessoas em situação de vulnerabilidade social e abastecer a rede pública de saúde com EPIs, equipamentos hospitalares e outros materiais necessários ao combate do Covid-19.</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.pesolidario.com.br">https://www.pesolidario.com.br</a></li>
-            </ul>
-          </li>
-
-          <li class="list_row">
-            <ul class="list_columns">
               <li><strong>Vizinhos Solidários</strong></li>
               <li>Doando amor em forma de alimento.</li>
               <li data-th="Cidade">Recife</li>
@@ -113,15 +104,6 @@
 
           <li class="list_row">
             <ul class="list_columns">
-              <li><strong>MSTS (Movimento dos Trabalhadores Sem Teto)</strong></li>
-              <li>Campanha de arrecadação financeira em caráter permanente até o fim da crise para ajudar continuamente famílias da população sem teto. A campanha começou em alguns estados (entre eles PE) e está em sua quarta etapa, ampliando o apoio para todo o país.</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/ajude-os-sem-teto-a-enfrentar-o-coronavirus">https://www.vakinha.com.br/vaquinha/ajude-os-sem-teto-a-enfrentar-o-coronavirus</a></li>
-            </ul>
-          </li>
-
-          <li class="list_row">
-            <ul class="list_columns">
               <li><strong>Ação Comunitária Caranguejo Uçá</strong></li>
               <li>Campanha de arrecadação financeira para as famílias das pescadoras artesanais da cidade do Recife.</li>
               <li data-th="Cidade">Recife</li>
@@ -129,32 +111,6 @@
             </ul>
           </li>
 
-          <li class="list_row">
-            <ul class="list_columns">
-              <li><strong>Gestos – Soropositividade, Comunicação e Gênero</strong></li>
-              <li>Campanha de arrecadação financeira para ajudar pessoas em situação de grave insegurança alimentar que fazem parte da rede de atendimento da organização.</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.kickante.com.br/campanhas/ajude-mais-120-familias-que-precisam">https://www.kickante.com.br/campanhas/ajude-mais-120-familias-que-precisam</a></li>
-            </ul>
-          </li>
-
-          <li class="list_row">
-            <ul class="list_columns">
-              <li><strong>Avental do Bem</strong></li>
-              <li>Doação de aventais de manga longa impermeáveis para profissionais de saúde na linha de frente do combate ao Covid-19.</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/corrente-do-bem-avental-protecao-covid-19">https://www.vakinha.com.br/vaquinha/corrente-do-bem-avental-protecao-covid-19</a></li>
-            </ul>
-          </li>
-
-          <li class="list_row">
-            <ul class="list_columns">
-              <li><strong>De mãos dadas com a cultura</strong></li>
-              <li>De mãos dadas com a Cultura é uma ação sociocultural idealizada pelo Grupo Destramelar com o intuito de doar cestas básicas a artistas da cultura popular (dança, música, teatro, circo...) bem como entidades afins que promovem ações culturais em comunidades em Recife.</li>
-              <li data-th="Cidade">Recife</li>
-              <li data-th="Site/Instagram"><a class="-small" target="_blank" href="https://www.vakinha.com.br/vaquinha/de-maos-dadas-com-a-cultura">https://www.vakinha.com.br/vaquinha/de-maos-dadas-com-a-cultura</a></li>
-            </ul>
-          </li>
         </tbody>
       </section>
     </section>


### PR DESCRIPTION
This PR attempts to update general content:

1. Removed no longer available initiatives:

- Pernambuco Solidário 
- MSTS (Vakinha Encerrada)
- Gestos – Soropositividade, Comunicação e Gênero (Campanha Encerrada)
- Avental do Bem (Campanha Encerrada)

2. Removed no longer available initiatives and update links:
- ONG Juntos (Página deletada)
- Maracatu Nação Leão Coroado -> https://www.instagram.com/p/CNGo9TVL-P7 (Updated link)
- Núcleo de Apoio à Criança com Câncer -> https://www.instagram.com/p/COBQPIUguRv (Updated link)

  